### PR TITLE
Implement garbled integer utilities and bitwise operations

### DIFF
--- a/crates/interpreter/src/instructions/arithmetic.rs
+++ b/crates/interpreter/src/instructions/arithmetic.rs
@@ -13,9 +13,9 @@ pub fn add<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
 
-    let uint_op1 = ruint_to_garbled_uint(&op1);
-    let uint_op2 = ruint_to_garbled_uint(&op2);
-    let result = uint_op1.add(uint_op2);
+    let garbled_op1 = ruint_to_garbled_uint(&op1);
+    let garbled_op2 = ruint_to_garbled_uint(&op2);
+    let result = garbled_op1.add(garbled_op2);
 
     *op2 = garbled_uint_to_ruint(&result);
 }
@@ -24,9 +24,9 @@ pub fn mul<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::LOW);
     pop_top!(interpreter, op1, op2);
 
-    let uint_op1 = ruint_to_garbled_uint(&op1);
-    let uint_op2 = ruint_to_garbled_uint(&op2);
-    let result = uint_op1.mul(uint_op2);
+    let garbled_op1 = ruint_to_garbled_uint(&op1);
+    let garbled_op2 = ruint_to_garbled_uint(&op2);
+    let result = garbled_op1.mul(garbled_op2);
 
     *op2 = garbled_uint_to_ruint(&result);
 }
@@ -35,9 +35,9 @@ pub fn sub<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
 
-    let uint_op1 = ruint_to_garbled_uint(&op1);
-    let uint_op2 = ruint_to_garbled_uint(&op2);
-    let result = uint_op2.sub(uint_op1);
+    let garbled_op1 = ruint_to_garbled_uint(&op1);
+    let garbled_op2 = ruint_to_garbled_uint(&op2);
+    let result = garbled_op2.sub(garbled_op1);
 
     *op2 = garbled_uint_to_ruint(&result);
 }
@@ -46,9 +46,9 @@ pub fn div<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::LOW);
     pop_top!(interpreter, op1, op2);
     if !op2.is_zero() {
-        let uint_op1 = ruint_to_garbled_uint(&op1);
-        let uint_op2 = ruint_to_garbled_uint(&op2);
-        let result = uint_op1.div(uint_op2);
+        let garbled_op1 = ruint_to_garbled_uint(&op1);
+        let garbled_op2 = ruint_to_garbled_uint(&op2);
+        let result = garbled_op1.div(garbled_op2);
 
         *op2 = garbled_uint_to_ruint(&result);
     }
@@ -65,9 +65,9 @@ pub fn rem<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::LOW);
     pop_top!(interpreter, op1, op2);
     if !op2.is_zero() {
-        let uint_op1 = ruint_to_garbled_uint(&op1);
-        let uint_op2 = ruint_to_garbled_uint(&op2);
-        let result = uint_op1.rem(uint_op2);
+        let garbled_op1 = ruint_to_garbled_uint(&op1);
+        let garbled_op2 = ruint_to_garbled_uint(&op2);
+        let result = garbled_op1.rem(garbled_op2);
 
         *op2 = garbled_uint_to_ruint(&result);
     }

--- a/crates/interpreter/src/instructions/arithmetic.rs
+++ b/crates/interpreter/src/instructions/arithmetic.rs
@@ -54,6 +54,7 @@ pub fn div<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     }
 }
 
+//TODO: Implement circuit for signed division
 pub fn sdiv<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::LOW);
     pop_top!(interpreter, op1, op2);
@@ -72,24 +73,28 @@ pub fn rem<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     }
 }
 
+//TODO: Implement circuit for signed modulo
 pub fn smod<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::LOW);
     pop_top!(interpreter, op1, op2);
     *op2 = i256_mod(op1, *op2)
 }
 
+//TODO: Implement circuit for signed addition
 pub fn addmod<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::MID);
     pop_top!(interpreter, op1, op2, op3);
     *op3 = op1.add_mod(op2, *op3)
 }
 
+//TODO: Implement circuit for signed multiplication
 pub fn mulmod<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::MID);
     pop_top!(interpreter, op1, op2, op3);
     *op3 = op1.mul_mod(op2, *op3)
 }
 
+//TODO?: Implement circuit for signed exponentiation
 pub fn exp<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
     pop_top!(interpreter, op1, op2);
     gas_or_fail!(interpreter, gas::exp_cost(SPEC::SPEC_ID, *op2));

--- a/crates/interpreter/src/instructions/arithmetic.rs
+++ b/crates/interpreter/src/instructions/arithmetic.rs
@@ -1,38 +1,13 @@
 use core::ops::{Add, Div, Mul, Rem, Sub};
 
 use super::i256::{i256_div, i256_mod};
-use crate::{gas, Host, Interpreter};
-use compute::{self, uint::GarbledUint};
-use primitives::{ruint::Uint, U256};
+use crate::{
+    gas,
+    instructions::utility::{garbled_uint_to_ruint, ruint_to_garbled_uint},
+    Host, Interpreter,
+};
+use primitives::U256;
 use specification::hardfork::Spec;
-
-fn ruint_to_garbled_uint(value: &Uint<256, 4>) -> GarbledUint<256> {
-    let bytes: [u8; 32] = value.to_le_bytes();
-
-    let bits: Vec<bool> = bytes
-        .iter()
-        .flat_map(|&byte| (0..8).map(move |i| ((byte >> i) & 1) == 1))
-        .collect();
-
-    GarbledUint::<256>::new(bits)
-}
-
-fn garbled_uint_to_ruint(value: &GarbledUint<256>) -> Uint<256, 4> {
-    let bytes: Vec<u8> = value
-        .bits
-        .chunks(8)
-        .map(|chunk| {
-            chunk
-                .iter()
-                .enumerate()
-                .fold(0, |byte, (i, &bit)| byte | ((bit as u8) << i))
-        })
-        .collect();
-
-    let mut array = [0u8; 32];
-    array.copy_from_slice(&bytes);
-    Uint::from_le_bytes(array)
-}
 
 pub fn add<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
@@ -168,21 +143,6 @@ mod tests {
         wiring::EthereumWiring<database_interface::EmptyDBTyped<core::convert::Infallible>, ()>,
     > {
         DummyHost::default()
-    }
-
-    #[test]
-    fn test_ruint_to_garbled_uint() {
-        let value = Uint::<256, 4>::from(123456789u64);
-        let garbled = ruint_to_garbled_uint(&value);
-        assert_eq!(garbled.bits.len(), 256);
-    }
-
-    #[test]
-    fn test_garbled_uint_to_ruint() {
-        let value = Uint::<256, 4>::from(123456789u64);
-        let garbled = ruint_to_garbled_uint(&value);
-        let result = garbled_uint_to_ruint(&garbled);
-        assert_eq!(value, result);
     }
 
     #[test]

--- a/crates/interpreter/src/instructions/bitwise.rs
+++ b/crates/interpreter/src/instructions/bitwise.rs
@@ -28,12 +28,14 @@ pub fn gt<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     *op2 = U256::from(garbled_op1.gt(&garbled_op2));
 }
 
+// TODO: Implement in garbled circuits
 pub fn slt<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
     *op2 = U256::from(i256_cmp(&op1, op2) == Ordering::Less);
 }
 
+// TODO: Implement in garbled circuits
 pub fn sgt<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
@@ -113,6 +115,7 @@ pub fn byte<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
 }
 
 /// EIP-145: Bitwise shifting instructions in EVM
+// TODO: Implement in garbled circuits
 pub fn shl<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
     check!(interpreter, CONSTANTINOPLE);
     gas!(interpreter, gas::VERYLOW);
@@ -126,6 +129,7 @@ pub fn shl<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, _host: &
 }
 
 /// EIP-145: Bitwise shifting instructions in EVM
+// TODO: Implement in garbled circuits
 pub fn shr<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
     check!(interpreter, CONSTANTINOPLE);
     gas!(interpreter, gas::VERYLOW);
@@ -139,6 +143,7 @@ pub fn shr<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, _host: &
 }
 
 /// EIP-145: Bitwise shifting instructions in EVM
+// TODO: Implement in garbled circuits
 pub fn sar<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
     check!(interpreter, CONSTANTINOPLE);
     gas!(interpreter, gas::VERYLOW);

--- a/crates/interpreter/src/instructions/bitwise.rs
+++ b/crates/interpreter/src/instructions/bitwise.rs
@@ -101,6 +101,7 @@ pub fn not<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     *op1 = garbled_uint_to_ruint(&result);
 }
 
+// TODO: Implement in garbled circuits
 pub fn byte<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
@@ -115,28 +116,32 @@ pub fn byte<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
 }
 
 /// EIP-145: Bitwise shifting instructions in EVM
-// TODO: Implement in garbled circuits
 pub fn shl<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
     check!(interpreter, CONSTANTINOPLE);
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
+
     let shift = as_usize_saturated!(op1);
+
     *op2 = if shift < 256 {
-        *op2 << shift
+        let garbled_op2 = ruint_to_garbled_uint(&op2);
+        let shifted_op2 = garbled_op2 << shift;
+        garbled_uint_to_ruint(&shifted_op2)
     } else {
         U256::ZERO
     }
 }
 
 /// EIP-145: Bitwise shifting instructions in EVM
-// TODO: Implement in garbled circuits
 pub fn shr<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, _host: &mut H) {
     check!(interpreter, CONSTANTINOPLE);
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
     let shift = as_usize_saturated!(op1);
     *op2 = if shift < 256 {
-        *op2 >> shift
+        let garbled_op2 = ruint_to_garbled_uint(&op2);
+        let shifted_op2 = garbled_op2 >> shift;
+        garbled_uint_to_ruint(&shifted_op2)
     } else {
         U256::ZERO
     }

--- a/crates/interpreter/src/instructions/bitwise.rs
+++ b/crates/interpreter/src/instructions/bitwise.rs
@@ -1,5 +1,9 @@
 use super::i256::i256_cmp;
-use crate::{gas, Host, Interpreter};
+use crate::{
+    gas,
+    instructions::utility::{garbled_uint_to_ruint, ruint_to_garbled_uint},
+    Host, Interpreter,
+};
 use core::cmp::Ordering;
 use primitives::U256;
 use specification::hardfork::Spec;
@@ -7,13 +11,21 @@ use specification::hardfork::Spec;
 pub fn lt<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
-    *op2 = U256::from(op1 < *op2);
+
+    let uint_op1 = ruint_to_garbled_uint(&op1);
+    let uint_op2 = ruint_to_garbled_uint(&op2);
+
+    *op2 = U256::from(uint_op1.lt(&uint_op2));
 }
 
 pub fn gt<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
-    *op2 = U256::from(op1 > *op2);
+
+    let uint_op1 = ruint_to_garbled_uint(&op1);
+    let uint_op2 = ruint_to_garbled_uint(&op2);
+
+    *op2 = U256::from(uint_op1.gt(&uint_op2));
 }
 
 pub fn slt<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
@@ -31,7 +43,11 @@ pub fn sgt<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
 pub fn eq<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
-    *op2 = U256::from(op1 == *op2);
+
+    let uint_op1 = ruint_to_garbled_uint(&op1);
+    let uint_op2 = ruint_to_garbled_uint(&op2);
+
+    *op2 = U256::from(uint_op1.eq(&uint_op2));
 }
 
 pub fn iszero<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
@@ -43,25 +59,44 @@ pub fn iszero<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
 pub fn bitand<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
-    *op2 = op1 & *op2;
+
+    let uint_op1 = ruint_to_garbled_uint(&op1);
+    let uint_op2 = ruint_to_garbled_uint(&op2);
+    let result = uint_op1 & uint_op2;
+
+    *op2 = garbled_uint_to_ruint(&result);
 }
 
 pub fn bitor<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
-    *op2 = op1 | *op2;
+
+    let uint_op1 = ruint_to_garbled_uint(&op1);
+    let uint_op2 = ruint_to_garbled_uint(&op2);
+    let result = uint_op1 | uint_op2;
+
+    *op2 = garbled_uint_to_ruint(&result);
 }
 
 pub fn bitxor<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
-    *op2 = op1 ^ *op2;
+
+    let uint_op1 = ruint_to_garbled_uint(&op1);
+    let uint_op2 = ruint_to_garbled_uint(&op2);
+    let result = uint_op1 ^ uint_op2;
+
+    *op2 = garbled_uint_to_ruint(&result);
 }
 
 pub fn not<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1);
-    *op1 = !*op1;
+
+    let uint_op1 = ruint_to_garbled_uint(&op1);
+    let result = !uint_op1;
+
+    *op1 = garbled_uint_to_ruint(&result);
 }
 
 pub fn byte<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {

--- a/crates/interpreter/src/instructions/bitwise.rs
+++ b/crates/interpreter/src/instructions/bitwise.rs
@@ -12,20 +12,20 @@ pub fn lt<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
 
-    let uint_op1 = ruint_to_garbled_uint(&op1);
-    let uint_op2 = ruint_to_garbled_uint(&op2);
+    let garbled_op1 = ruint_to_garbled_uint(&op1);
+    let garbled_op2 = ruint_to_garbled_uint(&op2);
 
-    *op2 = U256::from(uint_op1.lt(&uint_op2));
+    *op2 = U256::from(garbled_op1.lt(&garbled_op2));
 }
 
 pub fn gt<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
 
-    let uint_op1 = ruint_to_garbled_uint(&op1);
-    let uint_op2 = ruint_to_garbled_uint(&op2);
+    let garbled_op1 = ruint_to_garbled_uint(&op1);
+    let garbled_op2 = ruint_to_garbled_uint(&op2);
 
-    *op2 = U256::from(uint_op1.gt(&uint_op2));
+    *op2 = U256::from(garbled_op1.gt(&garbled_op2));
 }
 
 pub fn slt<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
@@ -44,10 +44,10 @@ pub fn eq<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
 
-    let uint_op1 = ruint_to_garbled_uint(&op1);
-    let uint_op2 = ruint_to_garbled_uint(&op2);
+    let garbled_op1 = ruint_to_garbled_uint(&op1);
+    let garbled_op2 = ruint_to_garbled_uint(&op2);
 
-    *op2 = U256::from(uint_op1.eq(&uint_op2));
+    *op2 = U256::from(garbled_op1.eq(&garbled_op2));
 }
 
 pub fn iszero<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
@@ -60,9 +60,9 @@ pub fn bitand<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
 
-    let uint_op1 = ruint_to_garbled_uint(&op1);
-    let uint_op2 = ruint_to_garbled_uint(&op2);
-    let result = uint_op1 & uint_op2;
+    let garbled_op1 = ruint_to_garbled_uint(&op1);
+    let garbled_op2 = ruint_to_garbled_uint(&op2);
+    let result = garbled_op1 & garbled_op2;
 
     *op2 = garbled_uint_to_ruint(&result);
 }
@@ -71,9 +71,9 @@ pub fn bitor<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
 
-    let uint_op1 = ruint_to_garbled_uint(&op1);
-    let uint_op2 = ruint_to_garbled_uint(&op2);
-    let result = uint_op1 | uint_op2;
+    let garbled_op1 = ruint_to_garbled_uint(&op1);
+    let garbled_op2 = ruint_to_garbled_uint(&op2);
+    let result = garbled_op1 | garbled_op2;
 
     *op2 = garbled_uint_to_ruint(&result);
 }
@@ -82,9 +82,9 @@ pub fn bitxor<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1, op2);
 
-    let uint_op1 = ruint_to_garbled_uint(&op1);
-    let uint_op2 = ruint_to_garbled_uint(&op2);
-    let result = uint_op1 ^ uint_op2;
+    let garbled_op1 = ruint_to_garbled_uint(&op1);
+    let garbled_op2 = ruint_to_garbled_uint(&op2);
+    let result = garbled_op1 ^ garbled_op2;
 
     *op2 = garbled_uint_to_ruint(&result);
 }
@@ -93,8 +93,8 @@ pub fn not<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::VERYLOW);
     pop_top!(interpreter, op1);
 
-    let uint_op1 = ruint_to_garbled_uint(&op1);
-    let result = !uint_op1;
+    let garbled_op1 = ruint_to_garbled_uint(&op1);
+    let result = !garbled_op1;
 
     *op1 = garbled_uint_to_ruint(&result);
 }

--- a/crates/interpreter/src/instructions/utility.rs
+++ b/crates/interpreter/src/instructions/utility.rs
@@ -102,11 +102,32 @@ mod tests {
     #[test]
     fn test_negative_ruint_to_garbled_int() {
         let mut value = Uint::<256, 4>::from(10i64);
-    
+
         value = -value;
 
         let garbled = ruint_to_garbled_int(&value);
-    
-        assert_eq!(garbled.bits[U256::BITS-1], true);
+
+        assert_eq!(garbled.bits[U256::BITS - 1], true);
+    }
+
+    #[test]
+    fn test_garbled_int_to_ruint() {
+        let value = Uint::<256, 4>::from(123456789u64);
+        let garbled = ruint_to_garbled_int(&value);
+        let result = garbled_int_to_ruint(&garbled);
+        assert_eq!(value, result);
+    }
+
+    #[test]
+    fn test_negative_garbled_int_to_ruint() {
+        let mut value = Uint::<256, 4>::from(10i64);
+
+        value = -value;
+
+        let garbled = ruint_to_garbled_int(&value);
+        let result = garbled_int_to_ruint(&garbled);
+
+        assert_eq!(value, result);
+        assert_eq!(uint_to_i64(&result), -10i64)
     }
 }

--- a/crates/interpreter/src/instructions/utility.rs
+++ b/crates/interpreter/src/instructions/utility.rs
@@ -1,7 +1,59 @@
+use compute::uint::GarbledUint;
+use primitives::ruint::Uint;
+
 pub(crate) unsafe fn read_i16(ptr: *const u8) -> i16 {
     i16::from_be_bytes(core::slice::from_raw_parts(ptr, 2).try_into().unwrap())
 }
 
 pub(crate) unsafe fn read_u16(ptr: *const u8) -> u16 {
     u16::from_be_bytes(core::slice::from_raw_parts(ptr, 2).try_into().unwrap())
+}
+
+pub fn ruint_to_garbled_uint(value: &Uint<256, 4>) -> GarbledUint<256> {
+    let bytes: [u8; 32] = value.to_le_bytes();
+
+    let bits: Vec<bool> = bytes
+        .iter()
+        .flat_map(|&byte| (0..8).map(move |i| ((byte >> i) & 1) == 1))
+        .collect();
+
+    GarbledUint::<256>::new(bits)
+}
+
+pub fn garbled_uint_to_ruint(value: &GarbledUint<256>) -> Uint<256, 4> {
+    let bytes: Vec<u8> = value
+        .bits
+        .chunks(8)
+        .map(|chunk| {
+            chunk
+                .iter()
+                .enumerate()
+                .fold(0, |byte, (i, &bit)| byte | ((bit as u8) << i))
+        })
+        .collect();
+
+    let mut array = [0u8; 32];
+    array.copy_from_slice(&bytes);
+    Uint::from_le_bytes(array)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use primitives::ruint::Uint;
+
+    #[test]
+    fn test_ruint_to_garbled_uint() {
+        let value = Uint::<256, 4>::from(123456789u64);
+        let garbled = ruint_to_garbled_uint(&value);
+        assert_eq!(garbled.bits.len(), 256);
+    }
+
+    #[test]
+    fn test_garbled_uint_to_ruint() {
+        let value = Uint::<256, 4>::from(123456789u64);
+        let garbled = ruint_to_garbled_uint(&value);
+        let result = garbled_uint_to_ruint(&garbled);
+        assert_eq!(value, result);
+    }
 }

--- a/crates/interpreter/src/instructions/utility.rs
+++ b/crates/interpreter/src/instructions/utility.rs
@@ -1,8 +1,15 @@
-use compute::uint::GarbledUint;
+use compute::{int::GarbledInt, uint::GarbledUint};
 use primitives::ruint::Uint;
 
 pub(crate) unsafe fn read_i16(ptr: *const u8) -> i16 {
     i16::from_be_bytes(core::slice::from_raw_parts(ptr, 2).try_into().unwrap())
+}
+
+pub fn uint_to_i64(value: &Uint<256, 4>) -> i64 {
+    let bytes: [u8; 32] = value.to_le_bytes();
+    let mut array = [0u8; 8];
+    array.copy_from_slice(&bytes[0..8]);
+    i64::from_le_bytes(array)
 }
 
 pub(crate) unsafe fn read_u16(ptr: *const u8) -> u16 {
@@ -37,10 +44,38 @@ pub fn garbled_uint_to_ruint(value: &GarbledUint<256>) -> Uint<256, 4> {
     Uint::from_le_bytes(array)
 }
 
+pub fn ruint_to_garbled_int(value: &Uint<256, 4>) -> GarbledInt<256> {
+    let bytes: [u8; 32] = value.to_le_bytes();
+
+    let bits: Vec<bool> = bytes
+        .iter()
+        .flat_map(|&byte| (0..8).map(move |i| ((byte >> i) & 1) == 1))
+        .collect();
+
+    GarbledInt::<256>::new(bits)
+}
+
+pub fn garbled_int_to_ruint(value: &GarbledInt<256>) -> Uint<256, 4> {
+    let bytes: Vec<u8> = value
+        .bits
+        .chunks(8)
+        .map(|chunk| {
+            chunk
+                .iter()
+                .enumerate()
+                .fold(0, |byte, (i, &bit)| byte | ((bit as u8) << i))
+        })
+        .collect();
+
+    let mut array = [0u8; 32];
+    array.copy_from_slice(&bytes);
+    Uint::from_le_bytes(array)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use primitives::ruint::Uint;
+    use primitives::{ruint::Uint, U256};
 
     #[test]
     fn test_ruint_to_garbled_uint() {
@@ -55,5 +90,35 @@ mod tests {
         let garbled = ruint_to_garbled_uint(&value);
         let result = garbled_uint_to_ruint(&garbled);
         assert_eq!(value, result);
+    }
+
+    #[test]
+    fn test_ruint_to_garbled_int() {
+        let value = Uint::<256, 4>::from(123456789u64);
+        let garbled = ruint_to_garbled_int(&value);
+        assert_eq!(garbled.bits.len(), 256);
+    }
+
+    #[test]
+    fn test_negative_ruint_to_garbled_int() {
+        let mut value = Uint::<256, 4>::from(10i64);
+        // invert the bits
+        for i in 0..256 {
+            value.set_bit(i, !value.bit(i));
+        }
+        let converted = uint_to_i64(&value);
+
+        // print the i64 value
+        println!("{}", uint_to_i64(&value));
+
+        value = Uint::<256, 4>::from(10i64);
+
+        value = -value;
+        let converted = uint_to_i64(&value);
+
+        println!("{}", uint_to_i64(&value));
+
+        let garbled = ruint_to_garbled_int(&value);
+        assert_eq!(garbled.bits[0], true);
     }
 }

--- a/crates/interpreter/src/instructions/utility.rs
+++ b/crates/interpreter/src/instructions/utility.rs
@@ -102,23 +102,11 @@ mod tests {
     #[test]
     fn test_negative_ruint_to_garbled_int() {
         let mut value = Uint::<256, 4>::from(10i64);
-        // invert the bits
-        for i in 0..256 {
-            value.set_bit(i, !value.bit(i));
-        }
-        let converted = uint_to_i64(&value);
-
-        // print the i64 value
-        println!("{}", uint_to_i64(&value));
-
-        value = Uint::<256, 4>::from(10i64);
-
+    
         value = -value;
-        let converted = uint_to_i64(&value);
-
-        println!("{}", uint_to_i64(&value));
 
         let garbled = ruint_to_garbled_int(&value);
-        assert_eq!(garbled.bits[0], true);
+    
+        assert_eq!(garbled.bits[U256::BITS-1], true);
     }
 }


### PR DESCRIPTION
Introduce utilities for converting between regular and garbled integers, along with bitwise operations.

- lt
- gt
- eq
- bitand
- bitor
- bitxor
- shl
- shr

Add tests for the new functionalities and clean up existing code with comments and refactoring.