### PR TITLE
chore(dep): use external circuit-sdk/compute dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,6 +951,7 @@ dependencies = [
 [[package]]
 name = "circuit_macro"
 version = "0.1.0"
+source = "git+https://github.com/GatewayLabs/circuit-sdk#3d0b6321f54deddfa0b2be79efcc7cb9b24bfa59"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1018,6 +1019,7 @@ dependencies = [
 [[package]]
 name = "compute"
 version = "0.1.0"
+source = "git+https://github.com/GatewayLabs/circuit-sdk#3d0b6321f54deddfa0b2be79efcc7cb9b24bfa59"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 resolver = "2"
 default-members = ["crates/revm"]
 members = [
-    # binary 
+    # binary
     "bins/revme",
 
     # libraries
@@ -46,11 +46,13 @@ specification = { path = "crates/specification", package = "revm-specification",
 state = { path = "crates/state", package = "revm-state", version = "1.0.0", default-features = false }
 wiring = { path = "crates/wiring", package = "revm-wiring", version = "1.0.0", default-features = false }
 transaction = { path = "crates/wiring/transaction", package = "revm-transaction", version = "1.0.0", default-features = false }
-interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "10.0.1", features = ["serde"] }
+interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "10.0.1", features = [
+    "serde",
+] }
 inspector = { path = "crates/inspector", package = "revm-inspector", version = "1.0.0", default-features = false }
 precompile = { path = "crates/precompile", package = "revm-precompile", version = "11.0.1", default-features = false }
 statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "1.0.0", default-features = false }
-compute = { path = "../circuit-sdk/compute" }
+compute = { git = "https://github.com/GatewayLabs/circuit-sdk", package = "compute" }
 
 [workspace.package]
 license = "MIT"


### PR DESCRIPTION
> [!NOTE]
> Final PR for #5 

Update compute dependency in Cargo.toml to use external crate instead of expecting local dev to have a local build