### PR TITLE
Feat/jump opcodes

### DIFF
--- a/crates/interpreter/src/instructions/bitwise.rs
+++ b/crates/interpreter/src/instructions/bitwise.rs
@@ -6,8 +6,8 @@ use crate::{
     Host, Interpreter,
 };
 use compute::prelude::{CircuitExecutor, GateIndexVec};
-use primitives::U256;
 use core::cmp::Ordering;
+use primitives::U256;
 use specification::hardfork::Spec;
 
 pub fn lt<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
@@ -61,7 +61,8 @@ pub fn iszero<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
 
     let result = match op1 {
         StackValueData::Public(value) => {
-            let garbled_gates = StackValueData::Public(*value).to_garbled_value(&mut interpreter.circuit_builder);
+            let garbled_gates =
+                StackValueData::Public(*value).to_garbled_value(&mut interpreter.circuit_builder);
             let eq_result = interpreter.circuit_builder.eq(&garbled_gates, &zero_gates);
             StackValueData::Private(GateIndexVec::from(eq_result))
         }
@@ -249,7 +250,13 @@ mod tests {
                 .compile_and_execute(&output_indices.into())
                 .unwrap();
 
-            assert_eq!(garbled_uint_to_bool(&result), test.expected, "Failed for op1: {:?}, op2: {:?}", test.op1, test.op2);
+            assert_eq!(
+                garbled_uint_to_bool(&result),
+                test.expected,
+                "Failed for op1: {:?}, op2: {:?}",
+                test.op1,
+                test.op2
+            );
         }
     }
 
@@ -305,7 +312,13 @@ mod tests {
                 .compile_and_execute(&output_indices.into())
                 .unwrap();
 
-            assert_eq!(garbled_uint_to_bool(&result), test.expected, "Failed for op1: {:?}, op2: {:?}", test.op1, test.op2);
+            assert_eq!(
+                garbled_uint_to_bool(&result),
+                test.expected,
+                "Failed for op1: {:?}, op2: {:?}",
+                test.op1,
+                test.op2
+            );
         }
     }
 
@@ -361,7 +374,13 @@ mod tests {
                 .compile_and_execute(&output_indices.into())
                 .unwrap();
 
-            assert_eq!(garbled_uint_to_bool(&result), test.expected, "Failed for op1: {:?}, op2: {:?}", test.op1, test.op2);
+            assert_eq!(
+                garbled_uint_to_bool(&result),
+                test.expected,
+                "Failed for op1: {:?}, op2: {:?}",
+                test.op1,
+                test.op2
+            );
         }
     }
 
@@ -369,31 +388,31 @@ mod tests {
     fn test_iszero() {
         let mut interpreter = generate_interpreter();
         let mut host = generate_host();
-        
+
         struct TestCase {
             value: U256,
-            expected: bool
+            expected: bool,
         }
-    
+
         let test_cases = vec![
             TestCase {
                 value: U256::ZERO,
-                expected: true
+                expected: true,
             },
             TestCase {
                 value: U256::from(1u64),
-                expected: false
+                expected: false,
             },
             TestCase {
                 value: U256::from(0xffffffffffffffffu64),
-                expected: false
+                expected: false,
             },
             TestCase {
                 value: U256::from(0x8000000000000000u64),
-                expected: false
-            }
+                expected: false,
+            },
         ];
-    
+
         for test in test_cases.iter() {
             interpreter
                 .stack
@@ -401,24 +420,24 @@ mod tests {
                 .expect("Failed to push value to stack");
 
             println!("Value: {:?}", test.value);
-    
+
             iszero(&mut interpreter, &mut host);
-    
+
             let output_indices = interpreter.stack.pop().unwrap();
 
             println!("Output indices: {:?}", output_indices);
-            
+
             let result: GarbledUint256 = interpreter
                 .circuit_builder
                 .compile_and_execute(&output_indices.into())
                 .unwrap();
 
             println!("Result: {:?}", garbled_uint_to_bool(&result));
-    
+
             assert_eq!(
-                garbled_uint_to_bool(&result), 
+                garbled_uint_to_bool(&result),
                 test.expected,
-                "Failed for value: {:?}", 
+                "Failed for value: {:?}",
                 test.value
             );
         }
@@ -463,12 +482,17 @@ mod tests {
                 .compile_and_execute(&output_indices.into())
                 .unwrap();
 
-            assert_eq!(garbled_uint_to_ruint(&result), test.expected, "Failed for op1: {:?}", test.op1);
+            assert_eq!(
+                garbled_uint_to_ruint(&result),
+                test.expected,
+                "Failed for op1: {:?}",
+                test.op1
+            );
         }
     }
 
     #[test]
-    fn test_bitand () {
+    fn test_bitand() {
         let mut interpreter = generate_interpreter();
         let mut host = generate_host();
         struct TestCase {
@@ -479,19 +503,19 @@ mod tests {
 
         let test_cases = vec![
             TestCase {
-            op1: U256::from(0x1234567890abcdefu128),
-            op2: U256::from(0xfedcba0987654321u128),
-            expected: U256::from(1302686019935617313u64),
+                op1: U256::from(0x1234567890abcdefu128),
+                op2: U256::from(0xfedcba0987654321u128),
+                expected: U256::from(1302686019935617313u64),
             },
             TestCase {
-            op1: U256::from(0xffffffffffffffffu128),
-            op2: U256::from(0x0000000000000000u128),
-            expected: U256::from(0x0000000000000000u128),
+                op1: U256::from(0xffffffffffffffffu128),
+                op2: U256::from(0x0000000000000000u128),
+                expected: U256::from(0x0000000000000000u128),
             },
             TestCase {
-            op1: U256::from(0x0f0f0f0f0f0f0f0fu128),
-            op2: U256::from(0xf0f0f0f0f0f0f0f0u128),
-            expected: U256::from(0x0000000000000000u128),
+                op1: U256::from(0x0f0f0f0f0f0f0f0fu128),
+                op2: U256::from(0xf0f0f0f0f0f0f0f0u128),
+                expected: U256::from(0x0000000000000000u128),
             },
         ];
 
@@ -514,7 +538,13 @@ mod tests {
                 .compile_and_execute(&output_indices.into())
                 .unwrap();
 
-            assert_eq!(garbled_uint_to_ruint(&result), test.expected, "Failed for op1: {:?}, op2: {:?}", test.op1, test.op2);
+            assert_eq!(
+                garbled_uint_to_ruint(&result),
+                test.expected,
+                "Failed for op1: {:?}, op2: {:?}",
+                test.op1,
+                test.op2
+            );
         }
     }
 
@@ -553,7 +583,7 @@ mod tests {
                 op1: U256::from(0x3400u64),
                 op2: U256::from(0xdc00u64),
                 expected: U256::from(0xfc00u64),
-            }
+            },
         ];
 
         for test in test_cases.iter() {
@@ -574,17 +604,23 @@ mod tests {
                 .circuit_builder
                 .compile_and_execute(&output_indices.into())
                 .unwrap();
-                
+
             let actual = garbled_uint_to_ruint(&result);
 
-            assert_eq!(garbled_uint_to_ruint(&result), test.expected, 
-                "Failed for op1: 0x{:x}, op2: 0x{:x}\nGot: 0x{:x}\nExpected: 0x{:x}", 
-                test.op1, test.op2, actual, test.expected);
-                }
+            assert_eq!(
+                garbled_uint_to_ruint(&result),
+                test.expected,
+                "Failed for op1: 0x{:x}, op2: 0x{:x}\nGot: 0x{:x}\nExpected: 0x{:x}",
+                test.op1,
+                test.op2,
+                actual,
+                test.expected
+            );
+        }
     }
 
     #[test]
-    fn test_bitxor () {
+    fn test_bitxor() {
         let mut interpreter = generate_interpreter();
         let mut host = generate_host();
         struct TestCase {
@@ -623,7 +659,7 @@ mod tests {
                 op1: U256::from(0x3400u64),
                 op2: U256::from(0xdc00u64),
                 expected: U256::from(0xe800u64),
-            }
+            },
         ];
 
         for test in test_cases.iter() {
@@ -645,13 +681,17 @@ mod tests {
                 .compile_and_execute(&output_indices.into())
                 .unwrap();
 
-           
-                let actual = garbled_uint_to_ruint(&result);
-    
-                assert_eq!(garbled_uint_to_ruint(&result), test.expected, 
-                    "Failed for op1: 0x{:x}, op2: 0x{:x}\nGot: 0x{:x}\nExpected: 0x{:x}", 
-                    test.op1, test.op2, actual, test.expected);
+            let actual = garbled_uint_to_ruint(&result);
 
+            assert_eq!(
+                garbled_uint_to_ruint(&result),
+                test.expected,
+                "Failed for op1: 0x{:x}, op2: 0x{:x}\nGot: 0x{:x}\nExpected: 0x{:x}",
+                test.op1,
+                test.op2,
+                actual,
+                test.expected
+            );
         }
     }
 

--- a/crates/interpreter/src/instructions/control.rs
+++ b/crates/interpreter/src/instructions/control.rs
@@ -1,5 +1,8 @@
-use super::utility::{read_i16, read_u16};
-use crate::{gas, Host, InstructionResult, Interpreter, InterpreterResult};
+use super::utility::{garbled_uint_to_ruint, read_i16, read_u16};
+use crate::{
+    gas, interpreter::StackValueData, Host, InstructionResult, Interpreter, InterpreterResult,
+};
+use compute::uint::GarbledUint;
 use primitives::{Bytes, U256};
 use specification::hardfork::Spec;
 
@@ -19,8 +22,24 @@ pub fn rjumpi<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     // In spec it is +3 but pointer is already incremented in
     // `Interpreter::step` so for revm is +2.
     let mut offset = 2;
-    if !condition.to_u256().is_zero() {
-        offset += unsafe { read_i16(interpreter.instruction_pointer) } as isize;
+
+    match condition {
+        StackValueData::Public(condition) => {
+            if !condition.is_zero() {
+                offset += unsafe { read_i16(interpreter.instruction_pointer) } as isize;
+            }
+        }
+        StackValueData::Private(condition_gates) => {
+            if let Ok(result) = interpreter
+                .circuit_builder
+                .compile_and_execute::<256>(&condition_gates)
+            // NOTE: assume 256 bits due to public condition
+            {
+                if result != GarbledUint::zero() {
+                    offset += unsafe { read_i16(interpreter.instruction_pointer) } as isize;
+                }
+            }
+        }
     }
 
     interpreter.instruction_pointer = unsafe { interpreter.instruction_pointer.offset(offset) };
@@ -30,7 +49,22 @@ pub fn rjumpv<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     require_eof!(interpreter);
     gas!(interpreter, gas::CONDITION_JUMP_GAS);
     pop!(interpreter, case);
-    let case = as_isize_saturated!(case);
+    let case = match case {
+        StackValueData::Public(case) => {
+            as_isize_saturated!(case)
+        }
+        StackValueData::Private(case_gates) => {
+            if let Ok(result) = interpreter
+                .circuit_builder
+                .compile_and_execute::<256>(&case_gates)
+            {
+                let result = garbled_uint_to_ruint(&result);
+                as_isize_saturated!(result)
+            } else {
+                return;
+            }
+        }
+    };
 
     let max_index = unsafe { *interpreter.instruction_pointer } as isize;
     // for number of items we are adding 1 to max_index, multiply by 2 as each offset is 2 bytes
@@ -54,20 +88,54 @@ pub fn rjumpv<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
 pub fn jump<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::MID);
     pop!(interpreter, target);
-    jump_inner(interpreter, target.into());
+    jump_inner(interpreter, target);
 }
 
 pub fn jumpi<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
     gas!(interpreter, gas::HIGH);
     pop!(interpreter, target, cond);
 
-    if !cond.to_u256().is_zero() {
-        jump_inner(interpreter, target.into());
+    match cond {
+        StackValueData::Public(cond) => {
+            if !cond.is_zero() {
+                jump_inner(interpreter, target);
+            }
+        }
+        StackValueData::Private(cond) => {
+            match interpreter
+                .circuit_builder
+                .compile_and_execute::<256>(&cond)
+            {
+                Ok(result) => {
+                    if result != GarbledUint::zero() {
+                        jump_inner(interpreter, target);
+                    }
+                }
+                Err(_) => {
+                    interpreter.instruction_result = InstructionResult::InvalidJump; // NOTE: define granular error for gate execution error
+                    return;
+                }
+            };
+        }
     }
 }
 
 #[inline]
-fn jump_inner(interpreter: &mut Interpreter, target: U256) {
+fn jump_inner(interpreter: &mut Interpreter, target: StackValueData) {
+    let target = match target {
+        StackValueData::Public(target) => target,
+        StackValueData::Private(target) => match interpreter
+            .circuit_builder
+            .compile_and_execute::<256>(&target)
+        {
+            Ok(result) => garbled_uint_to_ruint(&result),
+            Err(_) => {
+                interpreter.instruction_result = InstructionResult::InvalidJump; // NOTE: define granular error for gate execution error
+                return;
+            }
+        },
+    };
+
     let target = as_usize_or_fail!(interpreter, target, InstructionResult::InvalidJump);
     if !interpreter.contract.is_valid_jump(target) {
         interpreter.instruction_result = InstructionResult::InvalidJump;
@@ -204,12 +272,16 @@ pub fn unknown<H: Host + ?Sized>(interpreter: &mut Interpreter, _host: &mut H) {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::instructions::utility::ruint_to_garbled_uint;
     use crate::{table::make_instruction_table, DummyHost, FunctionReturnFrame, Gas, Interpreter};
-    use bytecode::opcode::{CALLF, JUMPF, NOP, RETF, RJUMP, RJUMPI, RJUMPV, STOP};
+    use bytecode::opcode::{
+        CALLF, JUMP, JUMPDEST, JUMPF, JUMPI, NOP, PUSH1, RETF, RJUMP, RJUMPI, RJUMPV, STOP,
+    };
     use bytecode::{
         eof::{Eof, TypesSection},
         Bytecode,
     };
+    use compute::uint::GarbledUint256;
     use primitives::bytes;
     use specification::hardfork::PragueSpec;
     use std::sync::Arc;
@@ -241,6 +313,38 @@ mod test {
         interp.gas = Gas::new(10000);
 
         // dont jump
+        interp.step(&table, &mut host);
+        assert_eq!(interp.program_counter(), 3);
+        // jumps to last opcode
+        interp.step(&table, &mut host);
+        assert_eq!(interp.program_counter(), 7);
+    }
+
+    #[test]
+    fn rjumpi_private() {
+        let table = make_instruction_table::<DummyHost<DefaultEthereumWiring>, PragueSpec>();
+        let mut host = DummyHost::default();
+        let mut interp = Interpreter::new_bytecode(Bytecode::LegacyRaw(
+            [RJUMPI, 0x00, 0x03, RJUMPI, 0x00, 0x01, STOP, STOP].into(),
+        ));
+        interp.is_eof = true;
+
+        let garbled_one = GarbledUint::<256>::one();
+        let garbled_one_gates = interp.circuit_builder.input(&garbled_one);
+        interp
+            .stack
+            .push_stack_value_data(StackValueData::Private(garbled_one_gates))
+            .unwrap();
+
+        let garbled_zero = GarbledUint::<256>::zero();
+        let garbled_zero_gates = interp.circuit_builder.input(&garbled_zero);
+        interp
+            .stack
+            .push_stack_value_data(StackValueData::Private(garbled_zero_gates))
+            .unwrap();
+        interp.gas = Gas::new(10000);
+
+        // don't jump
         interp.step(&table, &mut host);
         assert_eq!(interp.program_counter(), 3);
         // jumps to last opcode
@@ -300,6 +404,185 @@ mod test {
         interp.stack.push(U256::from(1)).unwrap();
         interp.step(&table, &mut host);
         assert_eq!(interp.program_counter(), 8);
+    }
+
+    #[test]
+    fn rjumpv_private() {
+        let table = make_instruction_table::<DummyHost<DefaultEthereumWiring>, PragueSpec>();
+        let mut host = DummyHost::default();
+        let mut interp = Interpreter::new_bytecode(Bytecode::LegacyRaw(
+            [
+                RJUMPV,
+                0x01, // max index, 0 and 1
+                0x00, // first x0001
+                0x01,
+                0x00, // second 0x002
+                0x02,
+                NOP,
+                NOP,
+                NOP,
+                RJUMP,
+                0xFF,
+                (-12i8) as u8,
+                STOP,
+            ]
+            .into(),
+        ));
+        interp.is_eof = true;
+        interp.gas = Gas::new(1000);
+
+        // more then max_index
+        let garbled_ten = ruint_to_garbled_uint(&U256::from(10));
+        let garbled_ten_gates = interp.circuit_builder.input(&garbled_ten);
+        interp
+            .stack
+            .push_stack_value_data(StackValueData::Private(garbled_ten_gates))
+            .unwrap();
+        interp.step(&table, &mut host);
+        assert_eq!(interp.program_counter(), 6);
+
+        // cleanup
+        interp.step(&table, &mut host);
+        interp.step(&table, &mut host);
+        interp.step(&table, &mut host);
+        interp.step(&table, &mut host);
+        assert_eq!(interp.program_counter(), 0);
+
+        // jump to first index of vtable
+        let garbled_zero = ruint_to_garbled_uint(&U256::from(0));
+        let garbled_zero_gates = interp.circuit_builder.input(&garbled_zero);
+        interp
+            .stack
+            .push_stack_value_data(StackValueData::Private(garbled_zero_gates))
+            .unwrap();
+        interp.step(&table, &mut host);
+        assert_eq!(interp.program_counter(), 7);
+
+        // cleanup
+        interp.step(&table, &mut host);
+        interp.step(&table, &mut host);
+        interp.step(&table, &mut host);
+        assert_eq!(interp.program_counter(), 0);
+
+        // jump to second index of vtable
+        let garbled_one = ruint_to_garbled_uint(&U256::from(1));
+        let garbled_one_gates = interp.circuit_builder.input(&garbled_one);
+        interp
+            .stack
+            .push_stack_value_data(StackValueData::Private(garbled_one_gates))
+            .unwrap();
+        interp.step(&table, &mut host);
+        assert_eq!(interp.program_counter(), 8);
+    }
+
+    #[test]
+    fn jump() {
+        let table = make_instruction_table::<DummyHost<DefaultEthereumWiring>, PragueSpec>();
+        let mut host = DummyHost::default();
+
+        // 1) Test JUMP to a valid address = 3
+        let mut interp = Interpreter::new_bytecode(Bytecode::LegacyRaw(
+            [PUSH1, 0x04, JUMP, 0x01, JUMPDEST, STOP].into(),
+        ));
+        interp.is_eof = true;
+        interp.gas = Gas::new(10000);
+
+        interp.step(&table, &mut host);
+        interp.step(&table, &mut host);
+        assert_eq!(interp.program_counter(), 4, "jump to 4 should succeed");
+
+        // 2) Test JUMP to invalid address = 0
+        interp = Interpreter::new_bytecode(Bytecode::LegacyRaw(
+            [PUSH1, 0x00, JUMP, 0x01, JUMPDEST, STOP].into(),
+        ));
+        interp.is_eof = true;
+        interp.gas = Gas::new(10000);
+
+        interp.step(&table, &mut host);
+        interp.step(&table, &mut host);
+        assert_eq!(
+            interp.program_counter(),
+            3,
+            "jump to invalid address 0 should do nothing"
+        );
+    }
+
+    #[test]
+    fn jump_private() {
+        let table = make_instruction_table::<DummyHost<DefaultEthereumWiring>, PragueSpec>();
+        let mut host = DummyHost::default();
+        let mut interp =
+            Interpreter::new_bytecode(Bytecode::LegacyRaw([JUMP, 0x04, JUMPDEST, STOP].into()));
+        interp.is_eof = true;
+        interp.gas = Gas::new(10000);
+
+        // Create a private target address
+        let target = ruint_to_garbled_uint(&U256::from(2)); // JUMPDEST is at position 1
+        let target_gates = interp.circuit_builder.input(&target);
+
+        // Push the private target address onto the stack
+        interp
+            .stack
+            .push_stack_value_data(StackValueData::Private(target_gates))
+            .unwrap();
+
+        // Execute the step
+        interp.step(&table, &mut host); // JUMP
+                                        // Check if the program counter has jumped to the target address (1)
+        assert_eq!(interp.program_counter(), 2);
+    }
+
+    #[test]
+    fn jumpi() {
+        let table = make_instruction_table::<DummyHost<DefaultEthereumWiring>, PragueSpec>();
+        let mut host = DummyHost::default();
+        let mut interp = Interpreter::new_bytecode(Bytecode::LegacyRaw(
+            [JUMPI, 0x03, 0x00, JUMPDEST, STOP, STOP, STOP, STOP].into(),
+        ));
+        interp.is_eof = true;
+        interp.gas = Gas::new(10000);
+
+        // Push the condition (1) onto the stack
+        interp.stack.push(U256::from(1)).unwrap();
+        // Push the target address (3) onto the stack
+        interp.stack.push(U256::from(3)).unwrap();
+
+        // Execute the step
+        interp.step(&table, &mut host);
+        // Check if the program counter has jumped to the target address (3)
+        assert_eq!(interp.program_counter(), 3);
+    }
+
+    #[test]
+    fn jumpi_private() {
+        let table = make_instruction_table::<DummyHost<DefaultEthereumWiring>, PragueSpec>();
+        let mut host = DummyHost::default();
+        let mut interp = Interpreter::new_bytecode(Bytecode::LegacyRaw(
+            [JUMPI, 0x03, 0x00, JUMPDEST, STOP].into(),
+        ));
+        interp.is_eof = true;
+        interp.gas = Gas::new(10000);
+
+        // Create a private condition
+        let condition = GarbledUint256::one();
+        let condition_gates = interp.circuit_builder.input(&condition);
+
+        // Push the private condition onto the stack
+        interp
+            .stack
+            .push_stack_value_data(StackValueData::Private(condition_gates))
+            .unwrap();
+
+        // Push the target address (3) onto the stack
+        interp
+            .stack
+            .push_stack_value_data(StackValueData::Public(U256::from(3)))
+            .unwrap();
+
+        // Execute the step
+        interp.step(&table, &mut host);
+        // Check if the program counter has jumped to the target address (3)
+        assert_eq!(interp.program_counter(), 3);
     }
 
     fn dummy_eof() -> Eof {

--- a/crates/interpreter/src/instructions/macros.rs
+++ b/crates/interpreter/src/instructions/macros.rs
@@ -95,10 +95,8 @@ macro_rules! resize_memory {
     };
     ($interp:expr, $offset:expr, $len:expr, $ret:expr) => {
         let new_size = $offset.saturating_add($len);
-        let current_size = core::cmp::max(
-            $interp.shared_memory.len(),
-            $interp.private_memory.len()
-        );
+        let current_size =
+            core::cmp::max($interp.shared_memory.len(), $interp.private_memory.len());
         if new_size > current_size {
             #[cfg(feature = "memory_limit")]
             if $interp.shared_memory.limit_reached(new_size) {

--- a/crates/interpreter/src/interpreter/stack.rs
+++ b/crates/interpreter/src/interpreter/stack.rs
@@ -1,8 +1,8 @@
 use crate::{instructions::utility::ruint_to_garbled_uint, InstructionResult};
 use compute::prelude::{GateIndexVec, WRK17CircuitBuilder};
-use serde::{Deserialize, Serialize};
 use core::{fmt, ptr};
 use primitives::{FixedBytes, B256, U256};
+use serde::{Deserialize, Serialize};
 use std::vec::Vec;
 
 /// EVM interpreter stack limit.


### PR DESCRIPTION
- Implemented private condition checks for rjumpi, rjumpv, jump, and jumpi.
- Introduced gate compilation and execution paths (compile_and_execute::<256>) to evaluate garbled conditions.
- Return InvalidJump if gate execution fails or if the resulting target is invalid.
- Updated tests to cover private condition scenarios:
  - rjumpi_private
  - rjumpv_private
  - jump_private
  - jumpi_private